### PR TITLE
docs: add alternative music sources

### DIFF
--- a/Documentations/ai-generated-music.md
+++ b/Documentations/ai-generated-music.md
@@ -1,0 +1,22 @@
+# AI-Generated or Algorithmic Music
+
+Modern machine‑learning models and algorithmic composition tools can produce original music that carries no traditional copyright restrictions. By generating short clips on demand or bundling pre‑generated tracks, the app can provide quiz content without relying on existing songs.
+
+Because quiz participants usually need to recognize a tune, the generator should be able to create **sound‑alike** clips: short motifs that mimic the rhythm, harmony, or instrumentation of a popular song without reproducing the exact melody. Users could tune the generator with prompts such as “upbeat disco similar to *Stayin’ Alive*” or select from preconfigured presets that approximate well‑known styles. The resulting clip acts as a hint while remaining technically original.
+
+## Implementation Notes
+- Integrate an open‑source generator (e.g., Google's [Magenta](https://magenta.tensorflow.org/), Jukebox, or MuseNet) to create short melodies offline.
+- Add a “style prompt” UI so creators can request clips inspired by a given artist or track while avoiding direct copying.
+- Cache generated clips for reuse and allow users to adjust style parameters (genre, tempo, mood, instrumentation).
+- Provide an option to export generated music as audio files for quiz questions or embed them via the `AttachmentProvider`.
+- Clearly mark generated tracks so users know they are synthetic and may not perfectly match the original song.
+
+## Advantages
+- No licensing costs or infringement risk from existing recordings.
+- Endless variety; quizzes can be unique for each session.
+- Allows referencing the “feel” of famous songs without distributing the actual recordings.
+- Encourages creativity and experimentation among quiz creators.
+
+## Considerations
+- Quality of generated music may vary and might not match familiar tunes users expect.
+- Running models locally can be resource-intensive; server-side generation or lightweight algorithms may be needed.

--- a/Documentations/fair-use-snippets.md
+++ b/Documentations/fair-use-snippets.md
@@ -1,0 +1,19 @@
+# Short Snippets Under Fair Use
+
+Some jurisdictions allow limited use of copyrighted works without permission under "fair use" or "fair dealing" doctrines, especially for commentary, criticism, or educational purposes. A quiz that plays very short excerpts (e.g., 5–15 seconds) could fall into this category when shared privately among friends.
+
+For version 1 of the app this is the core approach: creators provide tiny clips of well‑known songs that are short enough to hint at the track without substituting for it. The documentation below should guide future implementations that rely on the same concept.
+
+## Implementation Notes
+- Enforce a maximum clip length (e.g., 6–10 seconds) when importing audio and warn if a clip exceeds this limit.
+- Include disclaimers that quiz creators are responsible for ensuring their use qualifies as fair use in their jurisdiction and that the operator may remove content on complaint.
+- Offer tools to trim, fade, and normalize clips so only a brief, recognizable portion is used.
+- When a quiz is shared, strip any metadata that could expose full-song details and optionally delete the quiz automatically after a short time to minimize distribution.
+
+## Advantages
+- Users can reference familiar songs without needing licenses.
+- Very small clips reduce the likelihood of takedown requests.
+
+## Considerations
+- Fair use is a legal defense, not a guaranteed right; the app operator could still receive complaints.
+- This approach may be unsuitable for commercial distribution or public quizzes; a different licensing model may be required for later versions.

--- a/Documentations/public-domain-and-cc-music.md
+++ b/Documentations/public-domain-and-cc-music.md
@@ -1,0 +1,18 @@
+# Public Domain and Creative Commons Music
+
+Using music that is either in the public domain or released under a Creative Commons (CC) license avoids many of the legal risks of distributing copyrighted material. Services like [Free Music Archive](https://freemusicarchive.org/) and [Jamendo](https://www.jamendo.com/start) expose catalogs of tracks that can be streamed or downloaded under permissive terms.
+
+## Implementation Notes
+- Integrate with an open catalog's API (for example, FMA or Jamendo) to let users search for tracks that are already cleared for reuse.
+- Store license metadata with each quiz entry so the app can display proper attribution when necessary.
+- Filter tracks by license to only allow those that permit reuse and redistribution in a quiz context.
+- Cache short clips locally to reduce bandwidth while respecting the original hosting provider's terms.
+
+## Advantages
+- Large library of free tracks spanning many genres.
+- Minimal legal exposure as long as license terms (e.g., attribution) are respected.
+- Users gain immediate access to music without providing their own files.
+
+## Considerations
+- Some CC licenses (like BY-NC) may prohibit commercial use. The app should let quiz creators review the license before selecting a track.
+- Attribution text or links may need to appear alongside quiz questions.

--- a/Documentations/royalty-free-libraries.md
+++ b/Documentations/royalty-free-libraries.md
@@ -1,0 +1,18 @@
+# Royalty-Free Music Libraries
+
+Stock music providers sell or offer subscriptions that grant broad reuse rights. By sourcing quiz tracks from a library like [Bensound](https://www.bensound.com/), [Incompetech](https://incompetech.com/), or commercial services (Artlist, Epidemic Sound), the app can include high-quality music without complex licensing negotiations.
+
+## Implementation Notes
+- Acquire a license or subscription that allows redistribution of short clips within an interactive app.
+- Host the licensed files yourself or bundle them with the app; avoid hot-linking to the provider unless the license explicitly allows it.
+- Maintain a manifest that records where each clip came from and the license terms.
+- Consider offering themed packs (e.g., jazz, electronic) based on the purchased catalog.
+
+## Advantages
+- Professional recordings with clear, straightforward licenses.
+- Predictable costs and no need for external API integrations.
+- The same licensed clips can be reused across multiple quizzes.
+
+## Considerations
+- Upfront licensing fees or recurring subscription costs.
+- Each provider's terms differ; ensure the license covers redistribution and quiz-style usage.

--- a/Documentations/user-uploaded-audio.md
+++ b/Documentations/user-uploaded-audio.md
@@ -1,0 +1,26 @@
+# User-Uploaded Audio
+
+Allowing users to upload their own audio clips gives them full control over quiz content while keeping the app provider out of the copyright chain. The quiz itself only references files stored on the creator's device or a personal cloud service.
+
+For the initial release the goal is to let every quiz stay portable: creators can point to audio that already exists on the recipient's device or bundle small clips directly with the quiz. This can be achieved by extending the existing `ResourceProvider` system so multiple sources of audio are supported transparently.
+
+## Implementation Notes
+- Provide an in-app file picker/recorder that lets users select MP3 or WAV files stored locally, record new clips, or import from common cloud services.
+- Expand the `ResourceProvider` abstraction to support several ways of resolving audio:
+  - **WebResourceProvider** – existing URLs to publicly reachable MP3 files.
+  - **ResourcesFolderProvider** – audio bundled inside the app’s `Resources` directory for offline sharing.
+  - **AddressablesProvider** – built‑in quiz packs distributed via Unity addressables.
+  - **AttachmentProvider** – embed small audio files (for example as base64 strings) directly inside the serialized quiz so the file travels with the quiz.
+- When sharing a quiz, transmit only metadata (file hashes, provider type, and optional URLs). Recipients resolve the audio via the same providers; if a file is missing they are prompted to supply or download it.
+- Offer helpers to upload missing clips to personal cloud storage and generate a shareable link that can be used by the `WebResourceProvider`.
+- Display clear terms requiring users to upload content only if they have the necessary rights.
+- Optional: implement fingerprinting or length limits to discourage full‑song uploads.
+
+## Advantages
+- Maximum flexibility: creators can use any audio they legally control.
+- No reliance on third-party streaming APIs.
+- The app avoids hosting or distributing potentially infringing files.
+
+## Considerations
+- Users may still violate copyright by uploading material they do not own; the app should include disclaimers and a takedown policy.
+- Quizzes shared online might fail if recipients do not possess the referenced audio files; fallback mechanisms or clear error messages are needed.


### PR DESCRIPTION
## Summary
- expand AI music doc with sound-alike generation and style prompts
- detail fair-use snippet workflow for v1 including clip-length enforcement
- outline ResourceProvider options so users can share custom audio

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adf3b216888328a5f54b88e0557aaa