### PR TITLE
refactor: migrate main navigation to ui toolkit

### DIFF
--- a/MusicQuiz/Assets/MusicQuiz.asmdef
+++ b/MusicQuiz/Assets/MusicQuiz.asmdef
@@ -5,7 +5,8 @@
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
         "GUID:9e24947de15b9834991c9d8411ea37cf",
         "GUID:84651a3751eca9349aac36a66bba901b",
-        "GUID:f6dcb950d1c40064aac6238fa5d8b529"
+        "GUID:f6dcb950d1c40064aac6238fa5d8b529",
+        "UnityEngine.UIElementsModule"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/MusicQuiz/Assets/Musicmania/Ui/Screens/MainMenu/MainScreen.cs
+++ b/MusicQuiz/Assets/Musicmania/Ui/Screens/MainMenu/MainScreen.cs
@@ -1,29 +1,46 @@
 ﻿#nullable enable
 
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using Musicmania.Data.Categories;
 using Musicmania.Exceptions;
 using Musicmania.Ui.Presenter;
+using Musicmania.Utils;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace Musicmania.Ui.Screens.MainMenu
 {
+    /// <summary>
+    ///     Main menu screen implemented using UI Toolkit.
+    /// </summary>
     public class MainScreen : ScreenBase
     {
         [SerializeField]
-        private MainScreenNavigationComposite? navigation;
+        private UIDocument? document;
 
-        [SerializeField]
+        private MainScreenNavigationComposite? navigation;
         private CategoryListPresenter? categoryListPresenter;
+        private readonly CancellableTaskCollection taskCollection = new();
+
+        private UIDocument Document => SerializeFieldNotAssignedException.ThrowIfNull(document);
 
         private MainScreenNavigationComposite Navigation => NotInitializedException.ThrowIfNull(navigation);
 
-        private CategoryListPresenter CategoryListPresenter => NotInitializedException.ThrowIfNull(categoryListPresenter);
-
+        /// <summary>
+        ///     Initializes the main screen with the provided context.
+        /// </summary>
+        /// <param name="contextToUse">The application context.</param>
         public override void Initialize(MusicmaniaContext contextToUse)
         {
             base.Initialize(contextToUse);
 
-            Navigation.Initialize(contextToUse);
-            CategoryListPresenter.Initialize(contextToUse);
+            var root = Document.rootVisualElement;
+            var navigationRoot = root.Q("mainScreenNavigation") ?? throw new InvalidOperationException("mainScreenNavigation element not found");
+            navigation = new MainScreenNavigationComposite(contextToUse, navigationRoot);
+
+            taskCollection.StartExecution(InitializeCategoriesAsync);
         }
 
         /// <summary>
@@ -32,6 +49,7 @@ namespace Musicmania.Ui.Screens.MainMenu
         public override void Show()
         {
             base.Show();
+            Navigation.Show();
         }
 
         /// <summary>
@@ -39,7 +57,31 @@ namespace Musicmania.Ui.Screens.MainMenu
         /// </summary>
         public override void Hide()
         {
+            Navigation.Hide();
             base.Hide();
+        }
+
+        /// <summary>
+        ///     Cleans up resources on destruction.
+        /// </summary>
+        private void OnDestroy()
+        {
+            navigation?.Dispose();
+            categoryListPresenter?.Dispose();
+            taskCollection.Dispose();
+        }
+
+        /// <summary>
+        ///     Loads categories and creates the corresponding UI elements.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token for async operations.</param>
+        private async UniTask InitializeCategoriesAsync(CancellationToken cancellationToken)
+        {
+            var categoriesResource = Context.ResourceManager.GetResource<CategoriesCollectionData>(Context.Settings.ResourceSettings.CategoriesFileLocation);
+            var categories = await categoriesResource.LoadAsync(cancellationToken);
+            var root = Document.rootVisualElement;
+            var listRoot = root.Q("categoryList") ?? root;
+            categoryListPresenter = new CategoryListPresenter(Context, listRoot, categories);
         }
     }
 }

--- a/MusicQuiz/Assets/Musicmania/Ui/Screens/MainMenu/MainScreenNavigationComposite.cs
+++ b/MusicQuiz/Assets/Musicmania/Ui/Screens/MainMenu/MainScreenNavigationComposite.cs
@@ -1,97 +1,111 @@
-﻿#nullable enable
+#nullable enable
 
-using Musicmania.Exceptions;
+using System;
 using Musicmania.Settings.Ui;
 using Musicmania.Ui.Controls;
-using System;
-using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace Musicmania.Ui.Screens.MainMenu
 {
-    public class MainScreenNavigationComposite : ScreenBase
+    /// <summary>
+    ///     Composite for the main screen navigation using UI Toolkit.
+    /// </summary>
+    public sealed class MainScreenNavigationComposite : VisualElement, IDisposable
     {
-        [SerializeField]
-        private ButtonControl? settingsButton;
+        private readonly MusicmaniaContext context;
 
-        [SerializeField]
-        private ButtonControl? openQuestionManagerButton;
+        private readonly ButtonControl settingsButton;
+        private readonly ButtonControl openQuestionManagerButton;
+        private readonly ButtonControl startRandomButton;
+        private readonly ButtonControl quitButton;
 
-        [SerializeField]
-        private ButtonControl? startRandom;
-
-        [SerializeField]
-        private ButtonControl? quitButton;
-
-        private ButtonControl SettingsButton => SerializeFieldNotAssignedException.ThrowIfNull(settingsButton);
-
-        private ButtonControl OpenQuestionManagerButton => SerializeFieldNotAssignedException.ThrowIfNull(openQuestionManagerButton);
-
-        private ButtonControl StartRandom => SerializeFieldNotAssignedException.ThrowIfNull(startRandom);
-
-        private ButtonControl QuitButton => SerializeFieldNotAssignedException.ThrowIfNull(quitButton);
-
-        private UITheme Theme => Context.ThemeProvider.CurrentTheme;
-
-
-        public override void Initialize(MusicmaniaContext contextToUse)
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MainScreenNavigationComposite"/> class.
+        /// </summary>
+        /// <param name="contextToUse">The application context.</param>
+        /// <param name="parent">The parent element to attach to.</param>
+        /// <exception cref="ArgumentNullException">Thrown when any required parameter is null.</exception>
+        public MainScreenNavigationComposite(MusicmaniaContext contextToUse, VisualElement parent)
         {
-            base.Initialize(contextToUse);
+            context = contextToUse ?? throw new ArgumentNullException(nameof(contextToUse));
+            _ = parent ?? throw new ArgumentNullException(nameof(parent));
 
-            Context.ThemeProvider.ThemeChanged += OnThemeChanged;
+            style.flexGrow = 1;
+            parent.Add(this);
 
-            SettingsButton.Initialize(Theme.ButtonStyle);
-            OpenQuestionManagerButton.Initialize(Theme.ButtonStyle);
-            StartRandom.Initialize(Theme.ButtonStyle);
-            QuitButton.Initialize(Theme.ButtonStyle);
+            context.ThemeProvider.ThemeChanged += OnThemeChanged;
 
-            SettingsButton.OnClick += OnSettingsButtonClicked;
-            OpenQuestionManagerButton.OnClick += OnOpenQuestionManagerButtonClicked;
-            StartRandom.OnClick += OnStartRandomButtonClicked;
-            QuitButton.OnClick += OnQuitButtonClicked;
-        }
+            settingsButton = CreateButton("Settings", OnSettingsButtonClicked);
+            openQuestionManagerButton = CreateButton("Question Manager", OnOpenQuestionManagerButtonClicked);
+            startRandomButton = CreateButton("Start Random", OnStartRandomButtonClicked);
+            quitButton = CreateButton("Quit", OnQuitButtonClicked);
 
-        private void OnOpenQuestionManagerButtonClicked(object sender, EventArgs e)
-        {
-            throw new NotImplementedException();
-        }
-
-        private void OnStartRandomButtonClicked(object sender, EventArgs e)
-        {
-            throw new NotImplementedException();
-        }
-
-        private void OnQuitButtonClicked(object sender, EventArgs e)
-        {
-            throw new NotImplementedException();
-        }
-
-        private void OnSettingsButtonClicked(object sender, EventArgs e)
-        {
-            throw new NotImplementedException();
-        }
-
-        private void OnThemeChanged(object sender, UITheme e)
-        {
-            SettingsButton.SetTheme(Theme.ButtonStyle);
-            OpenQuestionManagerButton.SetTheme(Theme.ButtonStyle);
-            StartRandom.SetTheme(Theme.ButtonStyle);
-            QuitButton.SetTheme(Theme.ButtonStyle);
+            Hide();
         }
 
         /// <summary>
-        ///     Shows the main menu screen.
+        ///     Shows the navigation composite.
         /// </summary>
-        public override void Show()
-        {
-            base.Show();
-        }
+        public void Show() => style.display = DisplayStyle.Flex;
 
         /// <summary>
-        ///     Hides the main menu screen.
+        ///     Hides the navigation composite.
         /// </summary>
-        public override void Hide()
+        public void Hide() => style.display = DisplayStyle.None;
+
+        /// <inheritdoc />
+        public void Dispose()
         {
-            base.Hide();
+            context.ThemeProvider.ThemeChanged -= OnThemeChanged;
+
+            settingsButton.OnClick -= OnSettingsButtonClicked;
+            openQuestionManagerButton.OnClick -= OnOpenQuestionManagerButtonClicked;
+            startRandomButton.OnClick -= OnStartRandomButtonClicked;
+            quitButton.OnClick -= OnQuitButtonClicked;
+
+            settingsButton.Dispose();
+            openQuestionManagerButton.Dispose();
+            startRandomButton.Dispose();
+            quitButton.Dispose();
+        }
+
+        private UITheme Theme => context.ThemeProvider.CurrentTheme;
+
+        private ButtonControl CreateButton(string text, EventHandler onClick)
+        {
+            var control = new ButtonControl(Theme.ButtonStyle) { Text = text };
+            control.OnClick += onClick;
+            Add(control);
+            return control;
+        }
+
+        private void OnThemeChanged(object? sender, UITheme e)
+        {
+            settingsButton.SetTheme(e.ButtonStyle);
+            openQuestionManagerButton.SetTheme(e.ButtonStyle);
+            startRandomButton.SetTheme(e.ButtonStyle);
+            quitButton.SetTheme(e.ButtonStyle);
+        }
+
+        private void OnSettingsButtonClicked(object? sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnOpenQuestionManagerButtonClicked(object? sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnStartRandomButtonClicked(object? sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void OnQuitButtonClicked(object? sender, EventArgs e)
+        {
+            throw new NotImplementedException();
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- instantiate navigation composite from `mainScreenNavigation` element
- load categories and render them with a `CategoryListPresenter` visual element
- make `ButtonControl` derive from UI Toolkit `Button` and use it directly in presenters
- document the UI Toolkit-based main screen
- reference `UnityEngine.UIElementsModule` in `MusicQuiz.asmdef`

## Testing
- `dotnet format` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acce4698e08328899faaa64bdaccad