### PR TITLE
Add adjustable camera blur shader

### DIFF
--- a/MusicQuiz/Assets/Musicmania/CameraControllers.meta
+++ b/MusicQuiz/Assets/Musicmania/CameraControllers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ee0dae6fdd74d4486b740a860dff5f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlur.shader
+++ b/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlur.shader
@@ -1,0 +1,58 @@
+Shader "Custom/CameraBlur"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+        _BlurAmount ("Blur Amount", Range(0,1)) = 0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" "Queue"="Overlay" }
+        Pass
+        {
+            ZWrite Off Cull Off ZTest Always
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+
+            sampler2D _MainTex;
+            float4 _MainTex_TexelSize;
+            float _BlurAmount;
+
+            struct appdata
+            {
+                float4 vertex : POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            struct v2f
+            {
+                float4 vertex : SV_POSITION;
+                float2 uv : TEXCOORD0;
+            };
+
+            v2f vert (appdata v)
+            {
+                v2f o;
+                o.vertex = UnityObjectToClipPos(v.vertex);
+                o.uv = v.uv;
+                return o;
+            }
+
+            fixed4 frag (v2f i) : SV_Target
+            {
+                float2 uv = i.uv;
+                float2 texel = _MainTex_TexelSize.xy * (_BlurAmount * 10.0);
+
+                fixed4 col = fixed4(0,0,0,0);
+                col += tex2D(_MainTex, uv + texel * float2(-1.0, -1.0));
+                col += tex2D(_MainTex, uv + texel * float2(-1.0,  1.0));
+                col += tex2D(_MainTex, uv + texel * float2( 1.0, -1.0));
+                col += tex2D(_MainTex, uv + texel * float2( 1.0,  1.0));
+                return col * 0.25;
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlur.shader.meta
+++ b/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlur.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: e1d84e1a2b3c4d5e6f7a8b9c0d1e2f3a
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlurController.cs
+++ b/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlurController.cs
@@ -1,0 +1,53 @@
+﻿#nullable enable
+
+using UnityEngine;
+
+namespace Musicmania.CameraControllers
+{
+    /// <summary>
+    ///     Applies a configurable full-screen blur effect while leaving UI Toolkit elements unaffected.
+    /// </summary>
+    [ExecuteInEditMode]
+    public class CameraBlurController : MonoBehaviour
+    {
+        /// <summary>
+        ///     Amount of blur to apply. 0 for no blur and 1 for maximum blur.
+        /// </summary>
+        [Range(0f, 1f)]
+        [SerializeField]
+        private float blurAmount;
+
+        /// <summary>
+        ///     Material that performs the blur pass.
+        /// </summary>
+        [SerializeField]
+        private Material? blurMaterial;
+
+        /// <summary>
+        ///     Gets or sets the amount of blur to apply.
+        /// </summary>
+        public float BlurAmount
+        {
+            get => blurAmount;
+            set => blurAmount = Mathf.Clamp01(value);
+        }
+
+        /// <summary>
+        ///     Renders the scene with the blur effect.
+        /// </summary>
+        /// <param name="src">Source render texture.</param>
+        /// <param name="dest">Destination render texture.</param>
+        private void OnRenderImage(RenderTexture src, RenderTexture dest)
+        {
+            if (blurMaterial != null)
+            {
+                blurMaterial.SetFloat("_BlurAmount", blurAmount);
+                Graphics.Blit(src, dest, blurMaterial);
+            }
+            else
+            {
+                Graphics.Blit(src, dest);
+            }
+        }
+    }
+}

--- a/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlurController.cs.meta
+++ b/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlurController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b2c3d4e5f60718293a4b5c6d7e8f90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- implement adjustable full-screen blur shader
- add controller to apply blur without affecting UI Toolkit elements
- relocate blur assets under Musicmania/CameraControllers

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b009c8f02c8328a9fcff8bf17d47b3