### PR TITLE
Fix blur shader compile error

### DIFF
--- a/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlur.shader
+++ b/MusicQuiz/Assets/Musicmania/CameraControllers/CameraBlur.shader
@@ -15,6 +15,7 @@ Shader "Custom/CameraBlur"
             HLSLPROGRAM
             #pragma vertex vert
             #pragma fragment frag
+            #include "UnityCG.cginc"
 
             sampler2D _MainTex;
             float4 _MainTex_TexelSize;


### PR DESCRIPTION
## Summary
- include UnityCG.cginc in CameraBlur shader to provide UnityObjectToClipPos

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b01bd89e988328aa3d7cddc333aa2a